### PR TITLE
Fix grammar in Cloudflare recommendation

### DIFF
--- a/src/config/survey-config.js
+++ b/src/config/survey-config.js
@@ -503,7 +503,7 @@ const cloudflareRecommendations = {
     benefits: [
       'Automatic PQC algorithm updates as standards evolve',
       'Global edge network optimized for PQC performance',
-      'Hybrid cryptography now support maintaining compatibility',
+      'Hybrid cryptography now supports maintaining compatibility',
       'Built-in end-to-end protection against future quantum threats'
     ],
     features: [


### PR DESCRIPTION
## Summary
- correct grammar in PQC recommendations text

## Testing
- `grep -n "Hybrid cryptography" -n src/config/survey-config.js`


------
https://chatgpt.com/codex/tasks/task_e_683a781da4208320bf47bfa01438eb90