### PR TITLE
Fix port mismatch in docs

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -59,12 +59,12 @@ src/
 1. Start a local web server in the `src/` directory:
    ```bash
    cd src/
-   python3 -m http.server 8080
+   python3 -m http.server 8000
    ```
 
 2. Open your browser and navigate to:
    ```
-   http://localhost:8080
+   http://localhost:8000
    ```
 
 ## Benefits of Refactoring


### PR DESCRIPTION
## Summary
- keep docs consistent about which port to use

## Testing
- `npm test` *(fails: missing `package.json`)*
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a7d48d05c8320a667c7cc825d9863