### PR TITLE
Improve screen reader accessibility for logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,8 @@
       <div class="py-4 flex items-center justify-between px-4 sm:px-0">
         <div class="flex items-center gap-4 sm:gap-8">
           <!-- Cloudflare Logo -->
-          <a href="#" class="flex items-center">
+          <a href="#" class="flex items-center" aria-label="Cloudflare home">
+            <span class="sr-only">Cloudflare home</span>
             <svg xmlns='http://www.w3.org/2000/svg' width="120" height="24" fill='none' viewBox='0 0 204 30' class="mt-1 sm:w-[140px] sm:h-[30px]">
               <g clip-path='url(#a)'>
                 <path fill='#FBAD41' d='M52.688 13.028c-.22 0-.437.008-.654.015a.297.297 0 0 0-.102.024.365.365 0 0 0-.236.255l-.93 3.249c-.401 1.397-.252 2.687.422 3.634.618.876 1.646 1.39 2.894 1.45l5.045.306c.15.008.28.08.359.199a.492.492 0 0 1 .051.434.64.64 0 0 1-.547.426l-5.242.306c-2.848.132-5.912 2.456-6.987 5.29l-.378 1a.28.28 0 0 0 .248.382h18.054a.48.48 0 0 0 .464-.35 13.12 13.12 0 0 0 .48-3.54c0-7.22-5.789-13.072-12.933-13.072'></path>

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -6,6 +6,18 @@ body {
   color: #222;
   background-color: #f7f7f8;
 }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 
 .cloudflare-gradient {
   background-color: #f6821f; /* Cloudflare orange */


### PR DESCRIPTION
## Summary
- add hidden screen-reader text for the header logo
- define `.sr-only` helper class

## Testing
- `echo 'No test suite'`


------
https://chatgpt.com/codex/tasks/task_e_683a7d4bf3448320b715020351eeb5eb