### PR TITLE
Remove slider init timeout

### DIFF
--- a/src/js/survey.js
+++ b/src/js/survey.js
@@ -131,20 +131,18 @@ function createWeightSlider(factor, container) {
   container.appendChild(weightSlider);
   
   // Add event listener for weight changes
-  setTimeout(() => {
-    const slider = document.getElementById(`weightSlider-${factor.id}`);
-    if (slider) {
-      slider.addEventListener('input', (e) => {
-        const newWeight = parseInt(e.target.value);
-        currentWeights[factor.id] = newWeight;
-        
-        // Update all instances of this weight label
-        document.querySelectorAll(`.weight-label-${factor.id}`).forEach(el => {
-          el.textContent = newWeight;
-        });
+  const slider = weightSlider.querySelector(`#weightSlider-${factor.id}`);
+  if (slider) {
+    slider.addEventListener('input', (e) => {
+      const newWeight = parseInt(e.target.value);
+      currentWeights[factor.id] = newWeight;
+
+      // Update all instances of this weight label
+      document.querySelectorAll(`.weight-label-${factor.id}`).forEach(el => {
+        el.textContent = newWeight;
       });
-    }
-  }, 100);
+    });
+  }
 }
 
 export function handleFormSubmission() {


### PR DESCRIPTION
## Summary
- initialize weight sliders without delay

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_683a7d4d229c83208f172f85c1dcedba